### PR TITLE
Remove space before parens in Body examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Comet is an MVU style pattern:
 ``` cs
 public class MyPage : View {
 	[Body]
-	View body () => new Text("Hello World");
+	View body() => new Text("Hello World");
 }
 ```
 
@@ -37,7 +37,7 @@ public class MyPage : View {
 	public MyPage() {
 		Body = body;
 	}
-	View body () => new Text("Hello World");
+	View body() => new Text("Hello World");
 }
 ```
 


### PR DESCRIPTION
This tripped me up when I was trying to understand the example code; space-before-function-parens is not a common style for C#, so it took me a little while to realize that `body` is just a regular function.

Not a big deal but since the README will be many people's introduction to Comet, it's probably worth tidying up.