### PR TITLE
Added dirty checking to GenerateStateClass

### DIFF
--- a/src/Comet.SourceGenerator/StateWrapperGenerator.cs
+++ b/src/Comet.SourceGenerator/StateWrapperGenerator.cs
@@ -13,13 +13,11 @@ namespace Comet.SourceGenerator
 	public class StateWrapperGenerator : ISourceGenerator
 	{
 		private const string attributeSource = @"
-  	[System.AttributeUsage(System.AttributeTargets.Assembly, AllowMultiple = true)]
-	internal class GenerateStateClassAttribute : System.Attribute
+  	[System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class, AllowMultiple = true)]
+	public class GenerateStateClassAttribute : System.Attribute
 	{
-		public GenerateStateClassAttribute(System.Type classType)
-		{
-			ClassType = classType;
-		}
+		public GenerateStateClassAttribute(){}
+		public GenerateStateClassAttribute(System.Type classType) => ClassType = classType;
 		public string ClassName { get; set; }
 		public System.Type ClassType { get; }
 		public string Namespace { get; set; }
@@ -39,34 +37,67 @@ namespace {{NameSpace}} {
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		public readonly {{ClassType}} OriginalModel;
+
+		bool shouldNotifyChanged = true;
+
 		public {{ClassName}} ({{ClassType}} model)
 		{
 			OriginalModel = model;
-			if (model is INotifyPropertyChanged inp)
+			if (model is INotifyPropertyChanged inpc)
 			{
-				inp.PropertyChanged += Inp_PropertyChanged;
+				inpc.PropertyChanged += Inpc_PropertyChanged;
 				shouldNotifyChanged = false;
 			}
 		}
 
-		bool shouldNotifyChanged = true;
-		private void Inp_PropertyChanged(object sender, PropertyChangedEventArgs e)
+		void Inpc_PropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			StateManager.OnPropertyChanged(this,e.PropertyName,null);
-			PropertyChanged?.Invoke(this, e);
+			StateManager.OnPropertyChanged(sender, e.PropertyName, null);
+			PropertyChanged?.Invoke(sender, e);
 		}
-		
+	
 		void NotifyPropertyChanged(object value, [CallerMemberName] string memberName = null){
 			if (shouldNotifyChanged) {
 				StateManager.OnPropertyChanged(this, memberName, value);
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(memberName));
 			}
-		} 
+		}
+		
 		void NotifyPropertyRead([CallerMemberName] string memberName = null){ 
+			InitDirtyProperty(memberName);
 			StateManager.OnPropertyRead(this, memberName);
 			PropertyRead?.Invoke(this, new PropertyChangedEventArgs(memberName));
 		}
+		
+		/// <summary>
+		/// Notifies Comet of all changes in the underlying model (OriginalModel) observed properties 
+		/// </summary>
+		public void NotifyChanged(){
+			if (shouldNotifyChanged){
+				{{#Properties}}
+				{{#PropertiesUpdateAllFunc}}
+				{{/PropertiesUpdateAllFunc}}
+				{{/Properties}}
+			}
+		}
 
+		void InitDirtyProperty([CallerMemberName] string memberName = null){
+			switch (memberName){
+				{{#Properties}}
+				{{#PropertiesInitFunc}}
+				{{/PropertiesInitFunc}}
+				{{/Properties}}
+			}
+		}
+
+		void UpdateDirtyProperty([CallerMemberName] string memberName = null){
+			switch (memberName){
+				{{#Properties}}
+				{{#PropertiesUpdateFunc}}
+				{{/PropertiesUpdateFunc}}
+				{{/Properties}}
+			}
+		}
 		{{#Properties}}
 		{{#PropertiesFunc}}
 		{{/PropertiesFunc}}
@@ -77,39 +108,47 @@ namespace {{NameSpace}} {
 
 		static StateWrapperGenerator()
 		{
-			var interfacePropertyMustache = @"
-        public {{{Type}}} {{Name}} {
-			get {
-				NotifyPropertyRead();
-				return OriginalModel.{{Name}};
-			}
-            set {
-				OriginalModel.{{Name}} = value;
-				NotifyPropertyChanged(value);
-			}
-        }
-";
-			var interfacePropertySetOnlyMustache = @"
-        public {{{Type}}} {{Name}} {
-			set {
-				OriginalModel.{{Name}} = value;
-				NotifyPropertyChanged(value);
-			}
-        }
+
+			var interfacePropSupportMustache = @"
+		bool {{LName}}IsObserved = false;
+		bool {{LName}}IsDirty => {{LName}}IsObserved && !OriginalModel.{{Name}}.Equals({{LName}}LastValue);
+		{{{Type}}} {{LName}}LastValue;
 ";
 
-			var interfacePropertyGetOnlyMustache = @"
-        public {{{Type}}} {{Name}} {
+			var interfacePropertyMustache = interfacePropSupportMustache + 
+@"		public {{{Type}}} {{Name}} {
 			get {
 				NotifyPropertyRead();
 				return OriginalModel.{{Name}};
 			}
-        }
+			set {
+				OriginalModel.{{Name}} = value;
+				{{LName}}LastValue = value;
+				NotifyPropertyChanged(value);
+			}
+		}
+";
+			var interfacePropertySetOnlyMustache = interfacePropSupportMustache + 
+@"		public {{{Type}}} {{Name}} {
+			set {
+				OriginalModel.{{Name}} = value;
+				{{LName}}LastValue = value;
+				NotifyPropertyChanged(value);
+			}
+		}
+";
+
+			var interfacePropertyGetOnlyMustache = interfacePropSupportMustache + 
+@"		public {{{Type}}} {{Name}} {
+			get {
+				return OriginalModel.{{Name}};
+			}
+		}
 ";
 			interfacePropertyDictionary = new()
 			{
-				[(true,true)] = interfacePropertyMustache,
-				[(true,false)] = interfacePropertyGetOnlyMustache,
+				[(true, true)] = interfacePropertyMustache,
+				[(true, false)] = interfacePropertyGetOnlyMustache,
 				[(false, true)] = interfacePropertySetOnlyMustache,
 
 			};
@@ -136,16 +175,17 @@ namespace {{NameSpace}} {
 			yield return classType;
 			if (classType.BaseType != null)
 			{
-				foreach(var baseType in GetAllBaseTypes(classType.BaseType))
+				foreach (var baseType in GetAllBaseTypes(classType.BaseType))
 					yield return baseType;
 			}
 		}
 
 		dynamic GetModelData(string className, INamedTypeSymbol classType, string nameSpace)
 		{
-
 			var baseClasses = GetAllBaseTypes(classType).ToList();
 			List<(string Type, string Name)> properties = new();
+			List<(string Type, string Name)> methods = new();
+
 			List<string> propertiesWithSetters = new();
 			List<string> propertiesWithGetters = new();
 
@@ -167,7 +207,10 @@ namespace {{NameSpace}} {
 						propertiesWithSetters.Add(name);
 						continue;
 					}
-
+					//else if(m is IMethodSymbol mi && mi.DeclaredAccessibility == Accessibility.Public)
+					//{
+					//	var x = 0;
+					//}
 
 					string type = null;
 					List<(string Type, string Name)> parameters = new List<(string Type, string Name)>();
@@ -178,11 +221,33 @@ namespace {{NameSpace}} {
 						if (!properties.Contains(t))
 							properties.Add(t);
 					}
-
-
 				}
+
 			}
-			
+
+			var interfacePropInitMustache = 
+@"				case ""{{Name}}"":
+					if (!{{LName}}IsObserved){
+						{{LName}}LastValue = OriginalModel.{{Name}};
+						{{LName}}IsObserved = true;
+					}
+				break;
+";
+
+			var interfacePropUpdateMustache = 
+@"				case ""{{Name}}"": 
+					if ({{LName}}IsDirty){
+						{{LName}}LastValue = OriginalModel.{{Name}};
+						NotifyPropertyChanged({{LName}}LastValue, memberName);
+					}
+				break;
+";
+
+			var interfacePropUpdateAllMustache = 
+@"				if ({{LName}}IsObserved){
+					UpdateDirtyProperty(""{{Name}}"");
+				}
+";
 
 			var input = new {
 				ClassName = className,
@@ -191,6 +256,7 @@ namespace {{NameSpace}} {
 				Properties = properties.Select(x => new {
 					Type = x.Type,
 					Name = x.Name,
+					LName = x.Name.LowercaseFirst(),
 					HasSet = propertiesWithSetters.Contains(x.Name),
 					HasGet = propertiesWithGetters.Contains(x.Name),
 				}).ToList(),
@@ -198,20 +264,34 @@ namespace {{NameSpace}} {
 					var template = interfacePropertyDictionary[(dyn.HasGet, dyn.HasSet)];
 					return stubble.Render(template, dyn);
 				}),
+				PropertiesUpdateFunc = new Func<dynamic, string, object>((dyn, str) => {
+					var template = dyn.HasGet ? interfacePropUpdateMustache : "";
+					return stubble.Render(template, dyn);
+				}),
+				PropertiesUpdateAllFunc = new Func<dynamic, string, object>((dyn, str) => {
+					var template = dyn.HasGet ? interfacePropUpdateAllMustache : "";
+					return stubble.Render(template, dyn);
+				}),
+				PropertiesInitFunc = new Func<dynamic, string, object>((dyn, str) => {
+					var template = dyn.HasGet ? interfacePropInitMustache : "";
+					return stubble.Render(template, dyn);
+				})
+
 			};
 			return input;
 		}
 
 		public void Initialize(GeneratorInitializationContext context)
 		{
-			// if (!Debugger.IsAttached)
-			// {
-			// 	Debugger.Launch();
-			// }
+			//if (!Debugger.IsAttached)
+			//{
+			//	Debugger.Launch();
+			//}
 
 			context.RegisterForPostInitialization((pi) => pi.AddSource("GenerateStateClassAttribute__", attributeSource));
 			context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
 		}
+		//[assembly: GenerateStateClass(typeof(GTApp.POCOPlain))]
 
 		class SyntaxReceiver : ISyntaxContextReceiver
 		{
@@ -219,50 +299,62 @@ namespace {{NameSpace}} {
 
 			public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
 			{
-				var attrib = context.Node as AttributeSyntax;
-				if (attrib != null)
+				if (context.Node is ClassDeclarationSyntax cds && context.SemanticModel.GetDeclaredSymbol(cds).GetAttributes().Any(x => x.AttributeClass.Name == "GenerateStateClassAttribute"))
 				{
-					var type = context.SemanticModel.GetTypeInfo(attrib);
+					var realClass = context.SemanticModel.GetDeclaredSymbol(cds).OriginalDefinition as INamedTypeSymbol;//GetType(context, f);
+					string name = null;
+					string nameSpace = null;
+					name ??= $"{realClass.Name}State";
+					nameSpace ??= CometViewSourceGenerator.GetFullName(realClass.ContainingNamespace);
+					TemplateInfo.Add((name, realClass, nameSpace));
+
+
+					//List<SyntaxNode> childClassProps = cds.ChildNodes().Where(x => x is PropertyDeclarationSyntax pds && pds.Type.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.ClassDeclaration).Select(X => X).ToList();
+					// do
+					// {
+					// 	childClassProps = cds.ChildNodes().Where(x=>x is PropertyDeclarationSyntax pds)
+
+					// } while (childClassProps.Any());
+				}
+
+				if (context.Node is AttributeSyntax attrib)
+				{
 					if (context.SemanticModel.GetTypeInfo(attrib).Type?.ToDisplayString() == "GenerateStateClassAttribute")
 					{
+						if (attrib.ArgumentList == null) return;
+
+						var f = attrib.ArgumentList.Arguments[0].Expression as TypeOfExpressionSyntax;
+						var realClass = GetType(context, f);
+
+						string name = null;
+						string nameSpace = null;
+
+						foreach (var arg in attrib.ArgumentList.Arguments.Skip(1))
 						{
-
-							var f = attrib.ArgumentList.Arguments[0].Expression as TypeOfExpressionSyntax;
-							var realClass = GetType(context, f);
-
-							string name = null;
-							string nameSpace = null;
-
-							foreach (var arg in attrib.ArgumentList.Arguments.Skip(1))
+							var constVal = context.SemanticModel.GetConstantValue(arg.Expression);
+							var symbol = context.SemanticModel.GetSymbolInfo(arg.Expression);
+							var argName = arg.NameEquals?.Name.Identifier.ValueText;
+							if (argName == "ClassName")
 							{
-								var constVal = context.SemanticModel.GetConstantValue(arg.Expression);
-								var symbol = context.SemanticModel.GetSymbolInfo(arg.Expression);
-								var argName = arg.NameEquals?.Name.Identifier.ValueText;
-								if (argName == "ClassName")
-								{
-									name = constVal.ToString();
-									continue;
-								}
-
-								if (argName == "Namespace")
-								{
-									nameSpace = constVal.ToString();
-									continue;
-								}
-
-
-								var exp = arg.Expression;
+								name = constVal.ToString();
+								continue;
 							}
-							name ??= $"{realClass.Name}State";
-							nameSpace ??= CometViewSourceGenerator.GetFullName(realClass.ContainingNamespace);
 
-						
-
-							TemplateInfo.Add((name, realClass, nameSpace));
+							if (argName == "Namespace")
+							{
+								nameSpace = constVal.ToString();
+								continue;
+							}
 						}
+						name ??= $"{realClass.Name}State";
+						nameSpace ??= CometViewSourceGenerator.GetFullName(realClass.ContainingNamespace);
+						TemplateInfo.Add((name, realClass, nameSpace));
+
 					}
 				}
 			}
+
+			//	static 
 
 			static INamedTypeSymbol GetType(GeneratorSyntaxContext context, TypeOfExpressionSyntax expression)
 			{


### PR DESCRIPTION
Added dirty checking to GenerateStateClass to allow model Sync and Comet property change notifications.

I've tested with below scenario and it works well.

Usage Sample: Update underlying model with `comet.OriginalModel.Rides++;` and call the state classes `comet.SyncModels()` method to notify Comet of changes. In reality this would be done outside of a Comet click handler and invoked when the developer knows the underlying model has changed outside of a Comet state/binding.

### Usage:

```cs
[GenerateStateClass] //OR [assembly: GenerateStateClass(typeof(NS.POCOPlain))]
public class POCOPlain
{
	public int Rides { get; set; }
	public string CometTrain => "☄️".Repeat(Rides);
}

public class MainPage : View
{
	static readonly POCOPlain POCOPlain = new();
	readonly POCOPlainState comet = new(POCOPlain);

	[Body]
	View body()
		=> new VStack {
			new Text(()=> $"({comet.Rides}) rides taken:{comet.CometTrain}")
				.Frame(width:300)
				.LineBreakMode(LineBreakMode.CharacterWrap)
				.FillHorizontal(),

			new Button("Ride the Comet Sync! ☄️", ()=>{
				//comet.Rides++;
				comet.OriginalModel.Rides++;
				comet.NotifyChanged();
				})
				.Frame(height:44)
				.Margin(8)
				.Background(Colors.Green)
				.Color(Colors.White)
				.TextAlignment(TextAlignment.Center)
				.FillHorizontal()
		};
}
```

### Sample generated state class:

```cs
public partial class POCOPlainState :INotifyPropertyRead, IAutoImplemented 
{
    public event PropertyChangedEventHandler PropertyRead;
    public event PropertyChangedEventHandler PropertyChanged;

    public readonly GTApp.POCOPlain OriginalModel;

    bool shouldNotifyChanged = true;

    public POCOPlainState (GTApp.POCOPlain model)
    {
        OriginalModel = model;
        if (model is INotifyPropertyChanged inpc)
        {
            inpc.PropertyChanged += Inpc_PropertyChanged;
            shouldNotifyChanged = false;
        }
    }

    void Inpc_PropertyChanged(object sender, PropertyChangedEventArgs e)
    {
        StateManager.OnPropertyChanged(sender, e.PropertyName, null);
        PropertyChanged?.Invoke(sender, e);
    }

    void NotifyPropertyChanged(object value, [CallerMemberName] string memberName = null){
        if (shouldNotifyChanged) {
            StateManager.OnPropertyChanged(this, memberName, value);
            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(memberName));
        }
    }
    
    void NotifyPropertyRead([CallerMemberName] string memberName = null){ 
        InitDirtyProperty(memberName);
        StateManager.OnPropertyRead(this, memberName);
        PropertyRead?.Invoke(this, new PropertyChangedEventArgs(memberName));
    }
    
    /// <summary>
    /// Notifies Comet of all changes in the underlying model (OriginalModel) observed properties 
    /// </summary>
    public void NotifyChanged(){
        if (shouldNotifyChanged){
            if (ridesIsObserved){
                UpdateDirtyProperty("Rides");
            }
            if (cometTrainIsObserved){
                UpdateDirtyProperty("CometTrain");
            }
        }
    }

    void InitDirtyProperty([CallerMemberName] string memberName = null){
        switch (memberName){
            case "Rides":
                if (!ridesIsObserved){
                    ridesLastValue = OriginalModel.Rides;
                    ridesIsObserved = true;
                }
            break;
            case "CometTrain":
                if (!cometTrainIsObserved){
                    cometTrainLastValue = OriginalModel.CometTrain;
                    cometTrainIsObserved = true;
                }
            break;
        }
    }

    void UpdateDirtyProperty([CallerMemberName] string memberName = null){
        switch (memberName){
            case "Rides": 
                if (ridesIsDirty){
                    ridesLastValue = OriginalModel.Rides;
                    NotifyPropertyChanged(ridesLastValue, memberName);
                }
            break;
            case "CometTrain": 
                if (cometTrainIsDirty){
                    cometTrainLastValue = OriginalModel.CometTrain;
                    NotifyPropertyChanged(cometTrainLastValue, memberName);
                }
            break;
        }
    }

    bool ridesIsObserved = false;
    bool ridesIsDirty => ridesIsObserved && !OriginalModel.Rides.Equals(ridesLastValue);
    System.Int32 ridesLastValue;
    public System.Int32 Rides {
        get {
            NotifyPropertyRead();
            return OriginalModel.Rides;
        }
        set {
            OriginalModel.Rides = value;
            ridesLastValue = value;
            NotifyPropertyChanged(value);
        }
    }

    bool cometTrainIsObserved = false;
    bool cometTrainIsDirty => cometTrainIsObserved && !OriginalModel.CometTrain.Equals(cometTrainLastValue);
    System.String cometTrainLastValue;
    public System.String CometTrain {
        get {
            return OriginalModel.CometTrain;
        }
    }
}
```
