### PR TITLE
Specify tab indent_size in .editorconfig for better viewing experience on Github

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -120,7 +120,7 @@ dotnet_style_qualification_for_property = false:suggestion
 resharper_csharp_insert_final_newline=true
 resharper_csharp_wrap_lines=false
 
-[{*.md,*.sln,*.sln.DotSettings}]
+[{*.sln,*.sln.DotSettings}]
 #use tabs for indentation
 indent_style = tab
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,9 @@
 
 #Core editorconfig formatting - indentation
 
-#use soft tabs (spaces) for indentation
+#use tabs for indentation
 indent_style = tab
+indent_size = 4
 
 #Formatting - indentation options
 
@@ -118,3 +119,8 @@ dotnet_style_qualification_for_property = false:suggestion
 # ReSharper properties
 resharper_csharp_insert_final_newline=true
 resharper_csharp_wrap_lines=false
+
+[{*.md,*.sln,*.sln.DotSettings}]
+#use tabs for indentation
+indent_style = tab
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Comet is an MVU style pattern:
 
 ``` cs
 public class MyPage : View {
-	[Body]
-	View body () => new Text("Hello World");
+    [Body]
+    View body () => new Text("Hello World");
 }
 ```
 
@@ -33,10 +33,10 @@ or:
 
 ``` cs
 public class MyPage : View {
-	public MyPage() {
-		Body = body;
-	}
-	View body () => new Text("Hello World");
+    public MyPage() {
+        Body = body;
+    }
+    View body () => new Text("Hello World");
 }
 ```
 
@@ -49,9 +49,9 @@ Download and install the VS extension from the [Releases](https://github.com/Cla
 Then add to your `AppDelegate.cs` and/or `MainActivity.cs`, or similar. See the sample projects here for examples.
 
 ``` cs
- #if DEBUG
-            Comet.Reload.Init();
- #endif
+#if DEBUG
+Comet.Reload.Init();
+#endif
 ```
 
 
@@ -65,7 +65,7 @@ Just add a `State<T>` field to your View
 
 ``` cs
 class MyPage : View {
-	readonly State<int> clickCount = 1;
+    readonly State<int> clickCount = 1;
 }
 ```
 
@@ -80,19 +80,19 @@ Add it as a Field/Property, and add the `[State]` attribute!
 
 ``` cs
 public class MainPage : View {
-		class MyBindingObject : BindingObject {
-			public bool CanEdit {
-				get => GetProperty<bool> ();
-				set => SetProperty (value);
-			}
-			public string Text {
-				get => GetProperty<string> ();
-				set => SetProperty (value);
-			}
-		}
+    class MyBindingObject : BindingObject {
+        public bool CanEdit {
+            get => GetProperty<bool> ();
+            set => SetProperty (value);
+        }
+        public string Text {
+            get => GetProperty<string> ();
+            set => SetProperty (value);
+        }
+    }
 
-		[State]
-		readonly MyBindingObject state;
+    [State]
+    readonly MyBindingObject state;
 }
 
 ```
@@ -106,16 +106,16 @@ Simply update the stateful value and the framework handles the rest.
 ``` cs
 public class MyPage : View {
 
-	readonly State<int> clickCount = 1;
-	readonly State<string> text = "Hello World";
+    readonly State<int> clickCount = 1;
+    readonly State<string> text = "Hello World";
 
-	public MyPage() {
-		Body = () => new VStack {
-			new Text (text),			
-			new Button("Update Text", () => state.Text = $"Click Count: {clickCount.Value++}")
-		};
+    public MyPage() {
+        Body = () => new VStack {
+            new Text (text),			
+            new Button("Update Text", () => state.Text = $"Click Count: {clickCount.Value++}")
+        };
 
-	}
+    }
 }
 ```
 
@@ -130,16 +130,16 @@ Instead, use `new Text(()=> $"Click Count: {clickCount}")`.
 ``` cs
 public class MyPage : View {
 
-	readonly State<int> clickCount = new State<int> (1);
+    readonly State<int> clickCount = new State<int> (1);
 
-	public MyPage() {
-		Body = () => new VStack {
-			new Text (() => $"Click Count: {clickCount}"),
-			new Button("Update Text", () => {
-				clickCount.Value++;
-			}
-		};
-	}
+    public MyPage() {
+        Body = () => new VStack {
+            new Text (() => $"Click Count: {clickCount}"),
+            new Button("Update Text", () => {
+                clickCount.Value++;
+            }
+        };
+    }
 }
 
 ```


### PR DESCRIPTION
This PR adds tab indent_size to .editorconfig to make tab characters displayed only 4-character wide on Github instead of being displayed 8-character wide.

It also replaces tabs in README.md to 4 spaces for better reading experience.